### PR TITLE
Rewrite bsicons_replacer

### DIFF
--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -4,28 +4,37 @@
 This script replaces BSicons.
 
 
-The following parameters are supported:
+The following arguments are required:
 
 -config           The page title that has the JSON config (object).
-                  Any value in the object will overwrite the corresponding
-                  value in the object from -global_config.
-
--global_config    The page title that has the JSON config (object).
                   This page must be on Wikimedia Commons. Any value in the
                   object can be overwritten by a value in the object from
-                  -config.
+                  -local_config.
+
+The following arguments are supported:
+
+-local_config     The page title that has the JSON config (object).
+                  Any value in the object will overwrite the corresponding
+                  value in the object from -config.
+                  If not provided, it will be the same as -config.
 """
 # Author : JJMC89
 # License: MIT
+import copy
 import json
 import os
 import re
-import sys
 import mwparserfromhell
 import pywikibot
 from pywikibot import pagegenerators
-from pywikibot.bot import SingleSiteBot, ExistingPageBot, NoRedirectPageBot
+from pywikibot.bot import MultipleSitesBot, ExistingPageBot, NoRedirectPageBot
 
+BS_PREFIX_TEMPLATES = { # Temporary
+    'e': ['BSe', 'BS1e', 'FLe', 'FL1e', 'JBSu', 'JBS1u', 'ZCn', 'ZC1n', 'ŽČn',
+          'ŽČ1n'],
+    'u': ['BSu', 'BS1u', 'FLm', 'FL1m', 'ZCm', 'ZC1m', 'ŽČm', 'ŽČ1m'],
+    'ue': ['BSue', 'BS1ue', 'FLme', 'FL1me']
+}
 HTML_COMMENT = re.compile(r'<!--.*?-->', flags=re.S)
 ROUTEMAP_BSICON = re.compile(
     r'(?=((?:^|! !|!~|\\)[ \t]*)\b(.+?)\b([ \t]*(?:$|!~|~~|!@|__|!_|\\)))',
@@ -43,18 +52,44 @@ def get_json_from_page(page):
     @rtype: dict
     """
     if page.isRedirectPage():
-        pywikibot.log('%s is a redirect.' % page.title())
+        pywikibot.log('{} is a redirect.'.format(page.title()))
         page = page.getRedirectTarget()
     if not page.exists():
-        pywikibot.log('%s does not exist.' % page.title())
+        pywikibot.log('{} does not exist.'.format(page.title()))
         return dict()
     try:
         return json.loads(page.get().strip())
     except ValueError:
-        pywikibot.error('%s does not contain valid JSON.' % page.title())
+        pywikibot.error('{} does not contain valid JSON.'.format(page.title()))
         raise
     except pywikibot.PageRelatedError:
         return dict()
+
+
+def get_template_titles(templates):
+    """
+    Given an iterable of templates, return a set of titles.
+
+    @param templates: iterable of templates (L{pywikibot.Page})
+    @type templates: iterable
+
+    @rtype: set
+    """
+    titles = set()
+    for template in templates:
+        if template.isRedirectPage():
+            template = template.getRedirectTarget()
+        if not template.exists():
+            continue
+        titles.add(template.title(withNamespace=False))
+        titles.add(template.title(underscore=True, withNamespace=False))
+        for tpl in template.backlinks(
+                filterRedirects=True,
+                namespaces=template.site.namespaces.TEMPLATE
+        ):
+            titles.add(tpl.title(withNamespace=False))
+            titles.add(tpl.title(underscore=True, withNamespace=False))
+    return titles
 
 
 def validate_config(config, site):
@@ -69,46 +104,27 @@ def validate_config(config, site):
     @rtype: bool
     """
     pywikibot.log('Config:')
-    required_keys = ['redirects', 'repository']
+    required_keys = ['redirects']
     has_keys = list()
     for key, value in config.items():
-        pywikibot.log('-%s = %s' % (key, value))
+        pywikibot.log('-{} = {}'.format(key, value))
         if key in required_keys:
             has_keys.append(key)
         if key in 'blacklist' 'redirects' 'whitelist':
             if isinstance(value, str):
                 config[key] = [value]
             elif not isinstance(value, list):
-                return False
-        elif key in 'BS_templates' 'routemap_templates':
-            if isinstance(value, str):
-                config[key] = [value]
-            elif not isinstance(value, list):
-                return False
-            templates = set()
-            for tpl in config[key]:
-                page = pywikibot.Page(site, 'Template:%s' % tpl)
-                if page.exists():
-                    templates.add(page)
-            config[key] = templates
-        elif key == 'repository':
-            if not isinstance(value, bool):
-                return False
-            if value and site.has_image_repository:
-                file_site = site.image_repository()
-            else:
-                file_site = site
-        elif key == 'summary_prefix':
-            if not isinstance(value, str):
+                pywikibot.log('Invalid type.')
                 return False
     if sorted(has_keys) != sorted(required_keys):
+        pywikibot.log('Missing one more required keys.')
         return False
-    file_site.login()
     for key in ('blacklist', 'redirects', 'whitelist'):
         if key in config:
-            generator_factory = pagegenerators.GeneratorFactory(file_site)
+            generator_factory = pagegenerators.GeneratorFactory(site)
             for item in config[key]:
                 if not generator_factory.handleArg(item):
+                    pywikibot.log('Invalid generator.')
                     return False
             gen = generator_factory.getCombinedGenerator()
             config[key] = set(gen)
@@ -118,17 +134,81 @@ def validate_config(config, site):
         config.pop('redirects') - (config.pop('blacklist')
                                    - config.pop('whitelist'))
     )
-    config.pop('repository', None)
     replacement_map = config.pop('replacement_map', dict())
     if isinstance(replacement_map, str):
-        page = pywikibot.Page(file_site, replacement_map)
-        replacement_map = get_json_from_page(page) or dict()
+        page = pywikibot.Page(site, replacement_map)
+        replacement_map = get_json_from_page(page)
     if not isinstance(replacement_map, dict):
         replacement_map = dict()
     for value in replacement_map.values():
         if not isinstance(value, str):
+            pywikibot.log('Invalid type.')
             return False
     config['replacement_map'] = replacement_map
+    return True
+
+
+def validate_local_config(config, site):
+    """
+    Validate the local config and return bool.
+
+    @param config: config to validate
+    @type config: dict
+    @param site: site used in the validation
+    @type site: L{pywikibot.Site}
+
+    @rtype: bool
+    """
+    pywikibot.log('Config for {}:'.format(site))
+    required_keys = ['summary_prefix']
+    has_keys = list()
+    for key, value in config.items():
+        pywikibot.log('-{} = {}'.format(key, value))
+        if key in required_keys:
+            has_keys.append(key)
+        if key == 'BS_templates':
+            if isinstance(value, str):
+                config[key] = {'': [value]}
+            elif isinstance(value, list):
+                config[key] = {'': value}
+            elif not isinstance(value, dict):
+                pywikibot.log('Invalid type.')
+                return False
+            config[key].update(BS_PREFIX_TEMPLATES) # Temporary
+            tpl_map = dict()
+            for prefix, templates in config[key].items():
+                if isinstance(templates, str):
+                    templates = [templates]
+                elif not isinstance(templates, list):
+                    pywikibot.log('Invalid type.')
+                    return False
+                tpl_map[prefix] = get_template_titles([pywikibot.Page(
+                    site, 'Template:{}'.format(tpl)) for tpl in templates])
+            config[key] = tpl_map
+        elif key == 'routemap_templates':
+            if isinstance(value, str):
+                config[key] = [value]
+            elif not isinstance(value, list):
+                pywikibot.log('Invalid type.')
+                return False
+            config[key] = set()
+            for tpl in config[key]:
+                page = pywikibot.Page(site, 'Template:{}'.format(tpl))
+                config[key].union(get_template_titles(page))
+        elif key == 'summary_prefix':
+            if not isinstance(value, str):
+                pywikibot.log('Invalid type.')
+                return False
+    if sorted(has_keys) != sorted(required_keys):
+        pywikibot.log('Missing one more required keys.')
+        return False
+    if 'BS_templates' not in config and 'routemap_templates' not in config:
+        pywikibot.log('Missing templates.')
+        return False
+    elif 'BS_templates' not in config:
+        config['BS_templates'] = dict()
+    elif 'routemap_templates' not in config:
+        config['routemap_templates'] = set()
     return True
 
 
@@ -201,7 +281,7 @@ def get_bsicon_name(file):
         withNamespace=False)))[0][7:]
 
 
-class BSiconsReplacer(SingleSiteBot, ExistingPageBot, NoRedirectPageBot):
+class BSiconsReplacer(MultipleSitesBot, ExistingPageBot, NoRedirectPageBot):
     """Bot to replace BSicons."""
 
     def __init__(self, generator, **kwargs):
@@ -214,95 +294,52 @@ class BSiconsReplacer(SingleSiteBot, ExistingPageBot, NoRedirectPageBot):
         """
         self.availableOptions.update({
             'bsicons_map': dict(),
-            'BS_templates': set(),
-            'summary_prefix': 'Replace BSicon(s)',
-            'routemap_templates': set()
+            'config': dict(),
+            'local_config': None
         })
         self.generator = generator
         super().__init__(**kwargs)
-        self.bs_titles = self.get_template_titles(
-            self.getOption('BS_templates'))
-        self.routemap_titles = self.get_template_titles(
-            self.getOption('routemap_templates'))
-        self.prefix_map = {
-            'e': self.get_template_titles([
-                pywikibot.Page(self.site, 'Template:BSe'),
-                pywikibot.Page(self.site, 'Template:BS1e'),
-                pywikibot.Page(self.site, 'Template:FLe'),
-                pywikibot.Page(self.site, 'Template:FL1e'),
-                pywikibot.Page(self.site, 'Template:JBSu'),
-                pywikibot.Page(self.site, 'Template:JBS1u'),
-                pywikibot.Page(self.site, 'Template:ZCn'),
-                pywikibot.Page(self.site, 'Template:ZC1n'),
-                pywikibot.Page(self.site, 'Template:ŽČn'),
-                pywikibot.Page(self.site, 'Template:ŽČ1n')
-            ]),
-            'u': self.get_template_titles([
-                pywikibot.Page(self.site, 'Template:BSu'),
-                pywikibot.Page(self.site, 'Template:BS1u'),
-                pywikibot.Page(self.site, 'Template:FLm'),
-                pywikibot.Page(self.site, 'Template:FL1m'),
-                pywikibot.Page(self.site, 'Template:ZCm'),
-                pywikibot.Page(self.site, 'Template:ZC1m'),
-                pywikibot.Page(self.site, 'Template:ŽČm'),
-                pywikibot.Page(self.site, 'Template:ŽČ1m')
-            ]),
-            'ue': self.get_template_titles([
-                pywikibot.Page(self.site, 'Template:BSue'),
-                pywikibot.Page(self.site, 'Template:BS1ue'),
-                pywikibot.Page(self.site, 'Template:FLme'),
-                pywikibot.Page(self.site, 'Template:FL1me')
-            ]),
-        }
-
-    def get_template_titles(self, templates):
-        """
-        Given an iterable of templates, return a set of titles.
-
-        @param templates: iterable of templates (L{pywikibot.Page})
-        @type templates: iterable
-
-        @rtype: set
-        """
-        titles = set()
-        for template in templates:
-            if template.isRedirectPage():
-                template = template.getRedirectTarget()
-            if not template.exists():
-                continue
-            titles.add(template.title(withNamespace=False))
-            titles.add(template.title(underscore=True, withNamespace=False))
-            for tpl in template.backlinks(
-                    filterRedirects=True,
-                    namespaces=self.site.namespaces.TEMPLATE
-            ):
-                titles.add(tpl.title(withNamespace=False))
-                titles.add(tpl.title(underscore=True, withNamespace=False))
-        return titles
+        self._config = dict()
 
     def check_enabled(self):
         """Check if the task is enabled."""
-        if self._treat_counter % 6 != 0:
-            return
         page = pywikibot.Page(
-            self.site,
-            'User:%s/shutoff/%s' % (self.site.user(), self.__class__.__name__)
+            self.current_page.site,
+            'User:{username}/shutoff/{class_name}'.format(
+                username=self.current_page.site.user(),
+                class_name=self.__class__.__name__
+            )
         )
         if page.exists():
             content = page.get(force=True).strip()
             if content:
-                sys.exit('%s disabled:\n%s' %
-                         (self.__class__.__name__, content))
+                pywikibot.warning('{} disabled:\n{}'.format(
+                    self.__class__.__name__, content))
+                return False
+        return True
+
+    @property
+    def site_config(self):
+        """Return the site configuration."""
+        site = self.current_page.site
+        if site not in self._config:
+            self._config[site] = copy.deepcopy(self.getOption('config'))
+            self._config[site].update(get_json_from_page(pywikibot.Page(
+                site, self.getOption('local_config'))))
+            if not validate_local_config(self._config[site], site):
+                pywikibot.error('Invalid config for {}.'.format(site))
+                self._config[site] = None
+        return self._config[site]
 
     def treat_page(self):
         """Process one page."""
-        self.check_enabled()
+        if not (self.site_config and self.check_enabled()):
+            return
         text, mask = mask_html_tags(self.current_page.text)
         wikicode = mwparserfromhell.parse(text, skip_style_tags=True)
         replacements = set()
-        # Loop over all templates on the page.
         for tpl in wikicode.ifilter_templates():
-            if tpl.name.matches(self.routemap_titles):
+            if tpl.name.matches(self.site_config['routemap_templates']):
                 for param in tpl.params:
                     if not re.search(r'^map\d*$', str(param.name).strip()):
                         continue
@@ -311,33 +348,35 @@ class BSiconsReplacer(SingleSiteBot, ExistingPageBot, NoRedirectPageBot):
                     if not matches:
                         continue
                     for match in matches:
-                        if match[1] in self.getOption('bsicons_map'):
-                            replacement = self.getOption('bsicons_map')[
-                                match[1]]
-                            param_value = param_value.replace(
-                                ''.join(match),
-                                match[0] + replacement + match[2]
-                            )
-                            replacements.add('\u2192'.join([match[1],
-                                                            replacement]))
+                        replacement = self.getOption('bsicons_map').get(
+                            match[1], None)
+                        if not replacement:
+                            continue
+                        param_value = param_value.replace(
+                            ''.join(match),
+                            match[0] + replacement + match[2]
+                        )
+                        replacements.add('\u2192'.join([match[1],
+                                                        replacement]))
                     param.value = param_value
-            elif tpl.name.matches(self.bs_titles):
-                for param in tpl.params:
-                    param_value = HTML_COMMENT.sub('',
-                                                   str(param.value)).strip()
-                    prefix = ''
-                    if param.name.matches('1'):
-                        for key, value in self.prefix_map.items():
-                            if tpl.name.matches(value):
-                                prefix = key
-                                break
-                    current_icon = prefix + param_value
-                    if current_icon in self.getOption('bsicons_map'):
-                        new_icon = self.getOption('bsicons_map')[current_icon]
+            else:
+                for icon_prefix, tpl_titles in self.site_config[
+                        'BS_templates'].items():
+                    if not tpl.name.matches(tpl_titles):
+                        continue
+                    for param in tpl.params:
+                        prefix = icon_prefix if param.name.matches('1') else ''
+                        param_value = HTML_COMMENT.sub(
+                            '', str(param.value)).strip()
+                        current_icon = prefix + param_value
+                        new_icon = self.getOption('bsicons_map').get(
+                            current_icon, None)
+                        if not new_icon:
+                            continue
                         # The replacement must have the same prefix.
                         if new_icon[:len(prefix)] == prefix:
                             param.value = re.sub(
-                                r'\b%s\b' % re.escape(param_value),
+                                r'\b{}\b'.format(re.escape(param_value)),
                                 new_icon[len(prefix):],
                                 str(param.value)
                             )
@@ -345,7 +384,7 @@ class BSiconsReplacer(SingleSiteBot, ExistingPageBot, NoRedirectPageBot):
                                                             new_icon]))
         self.put_current(
             unmask_text(str(wikicode), mask),
-            summary='{}: {}'.format(self.getOption('summary_prefix'),
+            summary='{}: {}'.format(self.site_config['summary_prefix'],
                                     ', '.join(replacements))
         )
 
@@ -369,75 +408,67 @@ def main(*args):
             continue
         arg, _, value = arg.partition(':')
         arg = arg[1:]
-        if arg in 'config' 'global_config':
+        if arg in 'config' 'local_config':
             if not value:
                 value = pywikibot.input(
-                    'Please enter a value for %s' % arg,
+                    'Please enter a value for {}'.format(arg),
                     default=None
                 )
             options[arg] = value
         else:
             options[arg] = True
-    if 'config' not in options and 'global_config' not in options:
-        pywikibot.bot.suggest_help(
-            additional_text='Missing parameter(s) "config" or "global_config"'
-        )
+    if 'config' not in options:
+        pywikibot.bot.suggest_help(missing_parameters=['config'])
         return False
-    if 'global_config' in options:
-        config = get_json_from_page(pywikibot.Page(
-            pywikibot.Site('commons', 'commons'),
-            options.pop('global_config')
-        ))
-    else:
-        config = dict()
-    if 'config' in options:
-        config.update(get_json_from_page(
-            pywikibot.Page(site, options.pop('config'))))
+    elif 'local_config' not in options:
+        options['local_config'] = options['config']
+    config = get_json_from_page(pywikibot.Page(
+        site, options.pop('config')))
     if validate_config(config, site):
-        options.update(config)
+        options['config'] = config
     else:
         pywikibot.error('Invalid config.')
         return False
 
     bsicons_map = dict()
     pages = set()
-    for page in options.pop('redirects'):
-        # Must be a file redirect.
+    for page in options['config'].pop('redirects'):
+        # Must be a BSicon redirect.
         if not (page.isRedirectPage() and
-                isinstance(page, pywikibot.FilePage)):
+                isinstance(page, pywikibot.FilePage) and
+                page_is_bsicon(page)):
             continue
         # Target must be a file.
         try:
-            target_file = pywikibot.FilePage(page.getRedirectTarget())
+            replacement = pywikibot.FilePage(page.getRedirectTarget())
         except (pywikibot.IsNotRedirectPage, ValueError) as e:
             pywikibot.warning(e)
             continue
-        local_file = pywikibot.FilePage(site, page.title())
-        # Both must be BSicons.
-        if not (page_is_bsicon(local_file) and page_is_bsicon(target_file)):
+        # Target must be a BSicon.
+        if not page_is_bsicon(replacement):
             continue
-        bsicon_name = get_bsicon_name(local_file)
-        target_bsicon_name = get_bsicon_name(target_file)
+        bsicon_name = get_bsicon_name(page)
+        target_bsicon_name = get_bsicon_name(replacement)
         bsicons_map[bsicon_name] = target_bsicon_name
         if bsicon_name.find(' ') > -1:
             bsicons_map[bsicon_name.replace(' ', '_')] = target_bsicon_name
-        pages = pages.union(pagegenerators.FileLinksGenerator(local_file))
+        pages = pages.union(page.globalusage())
     for key, value in options.pop('replacement_map', dict()).items():
         try:
-            local_file = pywikibot.FilePage(site, key)
-            target_file = pywikibot.FilePage(site, value)
+            page = pywikibot.FilePage(site, key)
+            replacement = pywikibot.FilePage(site, value)
         except ValueError as e:
             pywikibot.warning(e)
             continue
         # Both must be BSicons.
-        if not (page_is_bsicon(local_file) and page_is_bsicon(target_file)):
+        if not (page_is_bsicon(page) and page_is_bsicon(replacement)):
             continue
-        bsicon_name = get_bsicon_name(local_file)
-        target_bsicon_name = get_bsicon_name(target_file)
+        bsicon_name = get_bsicon_name(page)
+        target_bsicon_name = get_bsicon_name(replacement)
         bsicons_map[bsicon_name] = target_bsicon_name
         if bsicon_name.find(' ') > -1:
             bsicons_map[bsicon_name.replace(' ', '_')] = target_bsicon_name
-        pages = pages.union(pagegenerators.FileLinksGenerator(local_file))
+        pages = pages.union(page.globalusage())
     if pages:
         options['bsicons_map'] = bsicons_map
         gen = (page for page in pages)

--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -402,11 +402,8 @@ class BSiconsReplacer(MultipleSitesBot, FollowRedirectPageBot,
                             continue
                         # The replacement must have the same prefix.
                         if new_icon[:len(prefix)] == prefix:
-                            param.value = re.sub(
-                                r'\b{}\b'.format(re.escape(param_value)),
-                                new_icon[len(prefix):],
-                                str(param.value)
-                            )
+                            param.value = str(param.value).replace(
+                                param_value, new_icon[len(prefix):])
                             replacements.add('\u2192'.join([current_icon,
                                                             new_icon]))
         self.put_current(

--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -29,12 +29,6 @@ import pywikibot
 from pywikibot import pagegenerators
 from pywikibot.bot import MultipleSitesBot, ExistingPageBot, NoRedirectPageBot
 
-BS_PREFIX_TEMPLATES = { # Temporary
-    'e': ['BSe', 'BS1e', 'FLe', 'FL1e', 'JBSu', 'JBS1u', 'ZCn', 'ZC1n', 'ŽČn',
-          'ŽČ1n'],
-    'u': ['BSu', 'BS1u', 'FLm', 'FL1m', 'ZCm', 'ZC1m', 'ŽČm', 'ŽČ1m'],
-    'ue': ['BSue', 'BS1ue', 'FLme', 'FL1me']
-}
 HTML_COMMENT = re.compile(r'<!--.*?-->', flags=re.S)
 ROUTEMAP_BSICON = re.compile(
     r'(?=((?:^|! !|!~|\\)[ \t]*)\b(.+?)\b([ \t]*(?:$|!~|~~|!@|__|!_|\\)))',
@@ -174,7 +168,6 @@ def validate_local_config(config, site):
             elif not isinstance(value, dict):
                 pywikibot.log('Invalid type.')
                 return False
-            config[key].update(BS_PREFIX_TEMPLATES) # Temporary
             tpl_map = dict()
             for prefix, templates in config[key].items():
                 if isinstance(templates, str):
@@ -365,7 +358,10 @@ class BSiconsReplacer(MultipleSitesBot, ExistingPageBot, NoRedirectPageBot):
                     if not tpl.name.matches(tpl_titles):
                         continue
                     for param in tpl.params:
-                        prefix = icon_prefix if param.name.matches('1') else ''
+                        if param.name.matches('1'):
+                            prefix = icon_prefix.strip()
+                        else:
+                            prefix = ''
                         param_value = HTML_COMMENT.sub(
                             '', str(param.value)).strip()
                         current_icon = prefix + param_value

--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -27,8 +27,8 @@ import re
 import mwparserfromhell
 import pywikibot
 from pywikibot import pagegenerators
-from pywikibot.bot import (MultipleSitesBot, ExistingPageBot,
-                           FollowRedirectPageBot)
+from pywikibot.bot import (MultipleSitesBot, FollowRedirectPageBot,
+                           ExistingPageBot)
 
 HTML_COMMENT = re.compile(r'<!--.*?-->', flags=re.S)
 ROUTEMAP_BSICON = re.compile(
@@ -275,8 +275,8 @@ def get_bsicon_name(file):
         withNamespace=False)))[0][7:]
 
 
-class BSiconsReplacer(MultipleSitesBot, ExistingPageBot,
-                      FollowRedirectPageBot):
+class BSiconsReplacer(MultipleSitesBot, FollowRedirectPageBot,
+                      ExistingPageBot):
     """Bot to replace BSicons."""
 
     def __init__(self, generator, **kwargs):

--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -27,7 +27,8 @@ import re
 import mwparserfromhell
 import pywikibot
 from pywikibot import pagegenerators
-from pywikibot.bot import MultipleSitesBot, ExistingPageBot, NoRedirectPageBot
+from pywikibot.bot import (MultipleSitesBot, ExistingPageBot,
+                           FollowRedirectPageBot)
 
 HTML_COMMENT = re.compile(r'<!--.*?-->', flags=re.S)
 ROUTEMAP_BSICON = re.compile(
@@ -274,7 +275,8 @@ def get_bsicon_name(file):
         withNamespace=False)))[0][7:]
 
 
-class BSiconsReplacer(MultipleSitesBot, ExistingPageBot, NoRedirectPageBot):
+class BSiconsReplacer(MultipleSitesBot, ExistingPageBot,
+                      FollowRedirectPageBot):
     """Bot to replace BSicons."""
 
     def __init__(self, generator, **kwargs):
@@ -449,7 +451,8 @@ def main(*args):
         if bsicon_name.find(' ') > -1:
             bsicons_map[bsicon_name.replace(' ', '_')] = target_bsicon_name
         pages = pages.union(page.globalusage())
-    for key, value in options.pop('replacement_map', dict()).items():
+    for key, value in options['config'].pop('replacement_map',
+                                            dict()).items():
         try:
             page = pywikibot.FilePage(site, key)
             replacement = pywikibot.FilePage(site, value)


### PR DESCRIPTION
- Use `globalusage()` (closes #12)
- Standardize BSicon names with percent-encoding or HTML entities (closes #13)
- Update config structure
- Follow redirects from generator
- Replacement in BS templates uses `str.replace()` instead of `re.sub()`
- `check_enabled()` to `disabled`, caches disabled sites
- `validate_local_config()` split from `validate_config()`
- `get_template_titles()`: method to function