### PR TITLE
[bsicons_replacer] Strip HTML comments in {{Routemap}} for current_icon and mask pipe magic words

### DIFF
--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -249,6 +249,7 @@ def mask_text(text, regex, mask=None):
 
 def unmask_text(text, mask):
     """Unmask text."""
+    text = text.replace('|***bot***=***param***|', '{{!}}')
     while text.find('***bot***masked***') > -1:
         for key, value in mask.items():
             text = text.replace('***bot***masked***{}***'.format(key), value)
@@ -263,6 +264,11 @@ def mask_html_tags(text, mask=None):
         flags=re.S
     )
     return mask_text(text, tags_regex, mask)
+
+
+def mask_pipe_mw(text):
+    """Mask the pipe magic word ({{!}})."""
+    return text.replace('{{!}}', '|***bot***=***param***|')
 
 
 def get_bsicon_name(file):
@@ -360,6 +366,7 @@ class BSiconsReplacer(MultipleSitesBot, FollowRedirectPageBot,
         if not self.site_config or self.site_disabled:
             return
         text, mask = mask_html_tags(self.current_page.text)
+        text = mask_pipe_mw(text)
         wikicode = mwparserfromhell.parse(text, skip_style_tags=True)
         replacements = set()
         for tpl in wikicode.ifilter_templates():

--- a/multi/bsicons_replacer.py
+++ b/multi/bsicons_replacer.py
@@ -373,14 +373,16 @@ class BSiconsReplacer(MultipleSitesBot, FollowRedirectPageBot,
                     if not matches:
                         continue
                     for match in matches:
-                        current_icon = standardize_bsicon_name(match[1])
+                        current_icon = standardize_bsicon_name(
+                            HTML_COMMENT.sub('', match[1]).strip())
                         new_icon = self.getOption('bsicons_map').get(
                             current_icon, None)
                         if not new_icon:
                             continue
                         param_value = param_value.replace(
                             ''.join(match),
-                            match[0] + new_icon + match[2]
+                            match[0] + match[1].replace(current_icon, new_icon)
+                            + match[2]
                         )
                         replacements.add('\u2192'.join([current_icon,
                                                         new_icon]))


### PR DESCRIPTION
- Strip HTML comments in `{{Routemap}}` for `current_icon`
  - For  #23
- Mask pipe magic words (`{{!}}`)
  - This is a workaround for #22.