### PR TITLE
feat(cfdw): Skip possibly conflicting instructions

### DIFF
--- a/enwiki/cfdw.py
+++ b/enwiki/cfdw.py
@@ -308,8 +308,7 @@ class CFDWPage(pywikibot.Page):
                 self._parse_section(str(section))
             except (ValueError, pywikibot.Error):
                 pywikibot.exception(tb=True)
-        self._check()
-        self._run_bot()
+        self._check_run()
 
     def _parse_section(self, section: str) -> None:
         """Parse a section and invoke the bot."""
@@ -392,8 +391,8 @@ class CFDWPage(pywikibot.Page):
                     results['cfd_page'] = CfdPage(page)
         return results
 
-    def _check(self) -> None:
-        """Check the instructions."""
+    def _check_run(self) -> None:
+        """Check and run the instructions."""
         instructions = list()
         seen = set()
         skip = set()
@@ -405,7 +404,7 @@ class CFDWPage(pywikibot.Page):
             seen.add(old_cat)
             for new_cat in instruction['bot_options']['new_cats']:
                 seen.add(new_cat)
-        # Only keep instructions that shouldn't be skipped.
+        # Only action instructions that shouldn't be skipped.
         for instruction in self.instructions:
             old_cat = instruction['bot_options']['old_cat']
             cats = {old_cat}
@@ -417,12 +416,8 @@ class CFDWPage(pywikibot.Page):
                 )
             elif check_instruction(instruction):
                 instructions.append(instruction)
+                do_instruction(instruction)
         self.instructions = instructions
-
-    def _run_bot(self) -> None:
-        """Run the bot."""
-        for instruction in self.instructions:
-            do_instruction(instruction)
 
 
 def add_old_cfd(

--- a/enwiki/cfdw.py
+++ b/enwiki/cfdw.py
@@ -311,7 +311,7 @@ class CFDWPage(pywikibot.Page):
         self._check_run()
 
     def _parse_section(self, section: str) -> None:
-        """Parse a section and invoke the bot."""
+        """Parse a section of a page."""
         cfd_page = None
         cfd_prefix = cfd_suffix = ''
         for line in section.splitlines():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mwparserfromhell
 python-dateutil
 pywikibot
+typing-extensions


### PR DESCRIPTION
Summary:
- Gather all (unchecked) instructions first
- If the old category is involved in any other instruction, skip the instruction.
- Action all instructions that passed checks

Code:
- Introduce CFDWPage for parsing
- Add typing, including typing-extensions