### PR TITLE
bump pywikibot-extensions from 24.9.21 to 26.4.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pydantic == 2.12.5
 pymysql == 1.1.2
 python-dateutil == 2.9.0.post0
 pywikibot [mysql,mwoauth] == 11.1.0
-pywikibot-extensions == 24.9.21
+pywikibot-extensions == 26.4.9


### PR DESCRIPTION
[T422859](https://phabricator.wikimedia.org/T422859)